### PR TITLE
feat: use level 1 - 3 to simplify for users 

### DIFF
--- a/source/php/Module/FireDangerLevels/FireDangerLevels.php
+++ b/source/php/Module/FireDangerLevels/FireDangerLevels.php
@@ -98,18 +98,16 @@ class FireDangerLevels extends \Modularity\Module
     private function getNoticeTypeFromLevel($level): string
     {
         return [
-            '4' => 'danger',
-            '5' => 'danger',
-            '5E' => 'danger-dark',
+            '2' => 'warning',
+            '3' => 'danger',
         ][$level] ?? 'success';
     }
 
     private function getIconNameFromLevel($level): string
     {
         return [
-            '4' => 'error',
-            '5' => 'error',
-            '5E' => 'error',
+            '2' => 'info',
+            '3' => 'error',
         ][$level] ?? 'check_circle';
     }
 
@@ -120,9 +118,8 @@ class FireDangerLevels extends \Modularity\Module
         $noRiskText = _x('No risk', 'fire danger level', 'api-alarm-integration');
 
         $text = [
-            '4' => $fireBanText,
-            '5' => $fireBanText,
-            '5E' => $fireBanText,
+            '2' => $fireBanText,
+            '3' => $fireBanText
         ][$level] ?? $noRiskText;
 
         return "$prefix $text";


### PR DESCRIPTION
This pull request includes significant changes to the `source/php/Module/FireDangerLevels/FireDangerLevels.php` file to update the fire danger levels and their corresponding notice types, icon names, and notice texts. The most important changes are listed below:

Updates to fire danger levels:

* [`getNoticeTypeFromLevel($level)`](diffhunk://#diff-3997ff2400b1b7ce3748b64c1a834e0acfda66bac6e124d7f676e931812c1f36L101-R110): Updated the mapping of fire danger levels to notice types, changing levels '4', '5', and '5E' to levels '2' and '3'.
* [`getIconNameFromLevel($level)`](diffhunk://#diff-3997ff2400b1b7ce3748b64c1a834e0acfda66bac6e124d7f676e931812c1f36L101-R110): Updated the mapping of fire danger levels to icon names, changing levels '4', '5', and '5E' to levels '2' and '3'.
* [`getNoticeTextFromLevel($level)`](diffhunk://#diff-3997ff2400b1b7ce3748b64c1a834e0acfda66bac6e124d7f676e931812c1f36L123-R122): Updated the mapping of fire danger levels to notice texts, changing levels '4', '5', and '5E' to levels '2' and '3'.